### PR TITLE
Adding dew point and specific humidity conversion to transform.py

### DIFF
--- a/glomar_gridding/transformation.py
+++ b/glomar_gridding/transformation.py
@@ -134,8 +134,7 @@ def dew_point_to_vapor_pressure(
     if dew_point_is_in_k:
         dew_point = dew_point - 273.15
     vapor_pressure = 611.21 * np.exp(
-        (17.502 * dew_point) /
-        (240.97 + dew_point)
+        (17.502 * dew_point) / (240.97 + dew_point)
     )
     return vapor_pressure
 
@@ -216,9 +215,10 @@ def vapor_pressure_to_specific_humidity(
     if use_mixing_ratio_approximation:
         return 1000.0 * gas_const_frac * vapor_pressure / air_pressure
     return (
-        1000.0 *
-        gas_const_frac * vapor_pressure /
-        (air_pressure - (1 - gas_const_frac) * vapor_pressure)
+        1000.0
+        * gas_const_frac
+        * vapor_pressure
+        / (air_pressure - (1 - gas_const_frac) * vapor_pressure)
     )
 
 
@@ -290,15 +290,12 @@ def dew_point_to_specific_humidity(
         Specific humidity or mixing ratio depending on the value of
         use_mixing_ratio_approximation. Units = g / kg
     """
-    return (
-        vapor_pressure_to_specific_humidity(
-            dew_point_to_vapor_pressure(
-                dew_point,
-                dew_point_is_in_k=dew_point_is_in_k
-            ),
-            air_pressure,
-            use_mixing_ratio_approximation=use_mixing_ratio_approximation,
-        )
+    return vapor_pressure_to_specific_humidity(
+        dew_point_to_vapor_pressure(
+            dew_point, dew_point_is_in_k=dew_point_is_in_k
+        ),
+        air_pressure,
+        use_mixing_ratio_approximation=use_mixing_ratio_approximation,
     )
 
 
@@ -335,13 +332,11 @@ def specific_humidity_to_dew_point(
         Dew point temperature, in K if output_in_k is True
         otherwise degree centigrade
     """
-    return (
-        vapor_pressure_to_dew_point(
-            specific_humidity_to_vapor_pressure(
-                specific_humidity,
-                air_pressure,
-                use_mixing_ratio_approximation=use_mixing_ratio_approximation,
-            ),
-            output_in_k=output_in_k,
-        )
+    return vapor_pressure_to_dew_point(
+        specific_humidity_to_vapor_pressure(
+            specific_humidity,
+            air_pressure,
+            use_mixing_ratio_approximation=use_mixing_ratio_approximation,
+        ),
+        output_in_k=output_in_k,
     )

--- a/glomar_gridding/transformation.py
+++ b/glomar_gridding/transformation.py
@@ -84,3 +84,264 @@ def inv_weibull_to_normality(
     lam = 0.2654 * c
     x = special.inv_boxcox(x_hat, lam)
     return x
+
+
+def dew_point_to_vapor_pressure(
+    dew_point: float,
+    dew_point_is_in_k: bool = True,
+):
+    """
+    Convert dew point to vapor pressure.
+    Same equation for temperature to saturation vapor pressure.
+
+    There are multiple formulas for this, depending on variation
+    of parameters within the Clausius-Clapeyron relation. AirSeaFluxCode
+    uses a simplified version of Buck (1981) (Eq 8):
+    https://doi.org/10.1175/1520-0450(1981)020<1527:NEFCVP>2.0.CO;2
+    per Biri et al (2023) section 2.3.
+
+    Often called the Magnus formula.
+
+    MetPy (a Python package) uses WMO
+    https://library.wmo.int/records/item/41650-guide-to-instruments-and-methods-of-observation
+    Volume 1, equation 4.3 (that equation works on mixing ratio)
+
+    Note:
+    Current version of airseaflux code says -32.19 if T in K
+    The correct value is actually -32.18...
+
+    Returned value is in Pa. The equation in Buck (1981) gives hPa.
+
+    Parameters
+    ----------
+    dew_point: float
+        Dew point (or temperature) value
+
+    dew_point_is_in_k: bool
+        Set to True if `dew point` is in Kelvins
+        Default is True
+        MAKE SURE YOU CHECK THIS.
+        Buck 1981 uses degree centigrade.
+
+    Returns
+    -------
+    vapor_pressure: float
+        (Saturation) vapor pressure from the given temperature
+        Saturation vapor pressure if dew_point is an actual temperature.
+        Partial vapor pressure if dew_point is dew point.
+        UNITS ARE IN Pascals (NOT hPa as in Buck 1981)
+    """
+    if dew_point_is_in_k:
+        dew_point = dew_point - 273.15
+    vapor_pressure = 611.21 * np.exp(
+        (17.502 * dew_point) /
+        (240.97 + dew_point)
+    )
+    return vapor_pressure
+
+
+temperature_to_saturation_vapor_pressure = dew_point_to_vapor_pressure
+
+
+def vapor_pressure_to_dew_point(
+    vapor_pressure: float,
+    output_in_k: bool = True,
+):
+    """
+    Inverse of `dew_point_to_vapor_pressure` of Buck (1981)
+    equation. While dew_point_to_vapor_pressure exists in AirSeaFlux code,
+    the inverse is missing. We are going to unbuck the Buck equation;
+    there will be no more buck passing. The buck stops here.
+
+    Parameters
+    ----------
+    vapor_pressure: float
+        Saturation or partial vapor pressure to H2O(g)
+
+    output_in_k: bool
+        Set to True if one wants `dew point` in Kelvins
+        Default is True
+        MAKE SURE YOU CHECK THIS.
+
+    Returns
+    -------
+    dew_point: float
+        Dew point or air temperature.
+        In Kelvins if output_in_kelvin is True
+    """
+    b = (np.log(vapor_pressure) - np.log(611.21)) / 17.502
+    h = 240.97 * b
+    t = 1 - b
+    dew_point = h / t
+    if output_in_k:
+        dew_point += 273.15
+    return dew_point
+
+
+saturation_vapor_pressure_to_temperature = vapor_pressure_to_dew_point
+
+
+def vapor_pressure_to_specific_humidity(
+    vapor_pressure: float,
+    air_pressure: float,
+    use_mixing_ratio_approximation: bool = False,
+):
+    """
+    Converts vapor pressure to specific humidity.
+    This function already exists in AirSeaFlux code in `qsat.py`,
+    but the inverse does not exist (see `specific_humidity_to_vapor_pressure`)
+
+    air_pressure and vapor_pressure should be in Pascals (not hPa)
+    Output units g/kg
+
+    Parameters
+    ----------
+    vapor_pressure: float
+        Partial vapor pressure to H2O(g)
+
+    air_pressure: float
+        Air pressure in PASCALS (not hPa)
+
+    use_mixing_ratio_approximation: bool
+        Outputs mixing ratio instead of specific humidity
+
+    Returns
+    -------
+    specific_humidity: float
+        Specific humidity or mixing ratio depending on
+        `use_mixing_ratio_approximation`. Units g/kg (MAKE SURE
+        YOU CHECK THIS)
+    """
+    gas_const_frac = 0.622
+    if use_mixing_ratio_approximation:
+        return 1000.0 * gas_const_frac * vapor_pressure / air_pressure
+    return (
+        1000.0 *
+        gas_const_frac * vapor_pressure /
+        (air_pressure - (1 - gas_const_frac) * vapor_pressure)
+    )
+
+
+def specific_humidity_to_vapor_pressure(
+    specific_humidity: float,
+    air_pressure: float,
+    use_mixing_ratio_approximation: bool = False,
+):
+    """
+    Inverse of `vapor_pressure_to_specific_humidity`
+
+    Parameters
+    ----------
+    specific_humidity: float
+        Specific humidity or mixing ratio depending on
+        `use_mixing_ratio_approximation`. Units is
+        g/kg (MAKE SURE YOU CHECK THIS)
+
+    air_pressure: float
+        Air pressure in PASCALS (not hPa)
+
+    use_mixing_ratio_approximation: bool
+        specific_humidity is mixing ratio
+
+    Returns
+    -------
+    vapor_pressure: float
+        Vapor pressure of H2O(g)
+    """
+    gas_const_frac = 0.622
+    a = specific_humidity / (1000 * gas_const_frac)
+    e_if_mixing_ratio = a * air_pressure
+    if use_mixing_ratio_approximation:
+        return e_if_mixing_ratio
+    return e_if_mixing_ratio / (1 + a * (1 - gas_const_frac))
+
+
+def dew_point_to_specific_humidity(
+    dew_point: float,
+    air_pressure: float,
+    dew_point_is_in_k: bool = True,
+    use_mixing_ratio_approximation: bool = False,
+):
+    """
+    Dew point to specific humidity
+
+    Parameters
+    ----------
+    dew_point: float
+        Dew point or air temperature,
+        units depend on dew_point_is_in_k,
+        kelvins or degree centigrade,
+        (MAKE SURE YOU CHECK THIS)
+
+    air_pressure: float
+        Air pressure in PASCALS (not hPa)
+
+    dew_point_is_in_k: bool
+        Set to True if one wants `dew point` in Kelvins
+        Default is True
+        MAKE SURE YOU CHECK THIS.
+
+    use_mixing_ratio_approximation: bool
+        specific_humidity is mixing ratio
+
+    Returns
+    -------
+    specific_humidity: float
+        Specific humidity or mixing ratio depending on the value of
+        use_mixing_ratio_approximation. Units = g / kg
+    """
+    return (
+        vapor_pressure_to_specific_humidity(
+            dew_point_to_vapor_pressure(
+                dew_point,
+                dew_point_is_in_k=dew_point_is_in_k
+            ),
+            air_pressure,
+            use_mixing_ratio_approximation=use_mixing_ratio_approximation,
+        )
+    )
+
+
+def specific_humidity_to_dew_point(
+    specific_humidity: float,
+    air_pressure: float,
+    use_mixing_ratio_approximation: bool = False,
+    output_in_k: bool = True,
+):
+    """
+    Specific humidity to dew_point
+
+    Parameters
+    ----------
+    specific_humidity: float
+        Specific humidity or mixing ratio depending on
+        `use_mixing_ratio_approximation`. Units is
+        g/kg (MAKE SURE YOU CHECK THIS)
+
+    air_pressure: float
+        Air pressure in PASCALS (not hPa)
+
+    use_mixing_ratio_approximation: bool
+        specific_humidity is mixing ratio
+
+    output_in_k: bool
+        Set to True if one wants `dew point` in Kelvins
+        Default is True
+        MAKE SURE YOU CHECK THIS.
+
+    Returns
+    -------
+    dew_point: float
+        Dew point temperature, in K if output_in_k is True
+        otherwise degree centigrade
+    """
+    return (
+        vapor_pressure_to_dew_point(
+            specific_humidity_to_vapor_pressure(
+                specific_humidity,
+                air_pressure,
+                use_mixing_ratio_approximation=use_mixing_ratio_approximation,
+            ),
+            output_in_k=output_in_k,
+        )
+    )


### PR DESCRIPTION
It basically fills in the gap where AirSeaFlux code is missing: it can only do one way conversion between the two variables.

- Uses Buck (1981) formula, which is what AirSeaFlux code uses (and is the method stated in the paper).
- Can be used to compute (saturation) vapour pressure.
- Since this is strictly a (inverse) transformation to a variable, it is added to transform.py
- There is function in `metpy` does the same thing, but `metpy` uses a slightly different formula which gives slightly different result. This only uses Buck (1981) equation. There are a quite few variations to temperature - vapour pressure relationship, which gives very similar results.
- It is probably useful to add the same functionality to the AirSeaFlux code. If it is here, then users don't have to import AirSeaFlux (or `metpy`) code to do the same.